### PR TITLE
Harden the logger + fs.mkdir

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,6 +200,13 @@ class AppendOnlyFSLogger {
       pendingWrites.join('\n') + '\n'
     )
 
+    /** If the fd is poisoned here then return an error */
+    if (!this.fd) {
+      return {
+        err: new Error('_flush() could not write, fd is null')
+      }
+    }
+
     /** Append the log to the end of the file */
     const { err: writeErr, data: bytesWritten } =
       await write(this.fd, buf, 0, buf.length, 0)

--- a/index.js
+++ b/index.js
@@ -88,8 +88,6 @@ class AppendOnlyFSLogger {
       return { err: new Error('Cannot open twice()') }
     }
 
-    this.hasOpened = true
-
     const dirname = path.dirname(this.logFileLocation)
     const { err: mkdirErr } = await mkdir(dirname, {
       recursive: true
@@ -152,8 +150,9 @@ class AppendOnlyFSLogger {
 
       return { err: err }
     }
-    this.fd = fd
 
+    this.hasOpened = true
+    this.fd = fd
     return {}
   }
 

--- a/renderer.js
+++ b/renderer.js
@@ -86,20 +86,28 @@ class RendererLogger {
     }
 
     function handleUncaught (err) {
-      /**
-       * This happens with a cross domain <script> tag where an
-       * uncaught exception occurred in some other <script> that
-       * does not belong to the current domain....
-       */
-      if (err === null) {
-        self.error('Uncaught exception in cross-domain <script>')
-        return
-      }
+      try {
+        /**
+         * This happens with a cross domain <script> tag where an
+         * uncaught exception occurred in some other <script> that
+         * does not belong to the current domain....
+         */
+        if (err === null) {
+          self.error('Uncaught exception in cross-domain <script>')
+          return
+        }
 
-      self.error('uncaught exception happened', {
-        err: err,
-        stack: err.stack || new Error('temp').stack
-      })
+        self.error('uncaught exception happened', {
+          err: err,
+          stack: err.stack || new Error('temp').stack
+        })
+      } catch (_err) {
+        /**
+         * If an uncaught exception happens in the uncaught
+         * exception then we cannot do much about it at all.
+         */
+        console.error('Uncaught in the handleUncaught()')
+      }
 
       return true
     }

--- a/renderer.js
+++ b/renderer.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const SEEN_VALUE = {}
+
 class RendererLogger {
   constructor (ipcRenderer, options = {}) {
     if (!ipcRenderer) throw new Error('ipcRenderer required')
@@ -86,6 +88,16 @@ class RendererLogger {
     }
 
     function handleUncaught (err) {
+      /**
+       * Sometimes window.onError and uncaughtException both
+       * fire so we set a unique value to avoid double logging
+       * the EXACT same uncaught exception.
+       */
+      if (err.__seen__ === SEEN_VALUE) {
+        return
+      }
+      err.__seen__ = SEEN_VALUE
+
       try {
         /**
          * This happens with a cross domain <script> tag where an

--- a/test/logger.js
+++ b/test/logger.js
@@ -133,6 +133,20 @@ test('open fails on write only file', async (assert) => {
   assert.end()
 })
 
+test('open on nested folder', async (assert) => {
+  const fileName = path.join(os.tmpdir(), uuid(), `${uuid()}.json`)
+
+  const logger = new AppendOnlyFSLogger(PRODUCT_NAME, {
+    fileName: fileName
+  })
+
+  const { err: err } = await logger.open()
+  assert.ifError(err)
+
+  fs.unlinkSync(fileName)
+  assert.end()
+})
+
 test('open two loggers on same fileName', async (assert) => {
   const logger = await makeLogger()
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -140,7 +140,7 @@ test('open on nested folder', async (assert) => {
     fileName: fileName
   })
 
-  const { err: err } = await logger.open()
+  const { err } = await logger.open()
   assert.ifError(err)
 
   fs.unlinkSync(fileName)
@@ -316,7 +316,7 @@ test('logging cyclic JSON', async (assert) => {
     const cyclic = {}
     cyclic.cyclic = cyclic
 
-    process.nextTick( () => {
+    process.nextTick(() => {
       logger.error('error', {
         msg: 'lol rekt son',
         err: err,


### PR DESCRIPTION
- Add fs.mkdir so that you can pass a nested directory
to the logger and it will create the directory for you.
 - Handle an edge case where we marked the logger as open
but it was not really open
 - Handle an edge case where the fd is null and we attempt
to write to it.
 - Handle an edge case where the logger throws an exception
and the uncaught exception listener calls the logger which
throws another exception, aka an infinite loop.

I noticed this in the `functions` app where the logger
would just write to STDOUT in a pretty tight loop upon
startup.